### PR TITLE
docs: add a license to the project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Visual Computing Group (Ulm University)
+Copyright (c) 2022 Visual Computing Group (Ulm University)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
We use the MIT license for this project so that use is relatively unrestricted.

fix #3