### PR TITLE
feat: add gradient variant

### DIFF
--- a/packages/missing-coordinates/src/PC.svelte
+++ b/packages/missing-coordinates/src/PC.svelte
@@ -4,6 +4,8 @@
   import AxisLabels from "./axes/AxisLabels.svelte";
   import Coordinates from "./coordinates/Coordinates.svelte";
   import MissingValuesAxis from "./axes/MissingValuesAxis.svelte";
+  import Gradients from "./gradients/Gradients.svelte";
+
   import {
     width,
     height,
@@ -13,7 +15,7 @@
     data as storeData,
   } from "./stores";
   import type { Data } from "./types";
-  import { DrawConfiguration, Concept } from "./types";
+  import { DrawConfiguration, Concept, Variation } from "./types";
 
   export let drawConfiguration: DrawConfiguration = new DrawConfiguration();
   export let data: Data;
@@ -24,6 +26,11 @@
 
 <main>
   <svg width={$width} height={$height}>
+    {#if $drawConfig.variation === Variation.GRADIENT}
+      <defs>
+        <Gradients />
+      </defs>
+    {/if}
     <g
       id="main-group"
       transform={`translate(${$drawConfig.margin.left}, ${$drawConfig.margin.top})`}

--- a/packages/missing-coordinates/src/coordinates/CoordinateSegment.svelte
+++ b/packages/missing-coordinates/src/coordinates/CoordinateSegment.svelte
@@ -23,6 +23,8 @@
   // Check whether the opacity of the line segment should be reduced.
   $: shouldReduceOpacity =
     $drawConfig.variation === Variation.OPACITY && (isAxis1Null || isAxis2Null);
+  // Set the stroke to the appropriate color/gradient.
+  $: stroke = getStroke($drawConfig.variation, isAxis1Null, isAxis2Null);
 
   function getCoordinatePosition(axis: AxisDescriptor): number | undefined {
     const value = coordinate.values[axis.name];
@@ -91,6 +93,30 @@
       $drawConfig.axisHeight
     );
   }
+
+  function getStroke(
+    variation: Variation,
+    axis1Null: boolean,
+    axis2Null: boolean
+  ) {
+    // If the gradient variant is used, apply gradients.
+    if (variation === Variation.GRADIENT) {
+      // Completely transparent
+      if (axis1Null && axis2Null) {
+        return "url(#missingGradientNull)";
+      }
+      // Increasing opacity
+      if (axis1Null) {
+        return "url(#missingGradientIncreasing)";
+      }
+      // Decreasing opacity
+      if (axis2Null) {
+        return "url(#missingGradientDecreasing)";
+      }
+    }
+    // Apply plain color.
+    return "black";
+  }
 </script>
 
 {#if axis1Pos !== undefined && axis2Pos !== undefined}
@@ -99,7 +125,7 @@
     x2={axis2.offset}
     y1={axis1Pos}
     y2={axis2Pos}
-    stroke="black"
+    {stroke}
     opacity={shouldReduceOpacity
       ? $drawConfig.missingValuesConfiguration.missingValueOpacity
       : 1}

--- a/packages/missing-coordinates/src/gradients/Gradients.svelte
+++ b/packages/missing-coordinates/src/gradients/Gradients.svelte
@@ -1,0 +1,17 @@
+<linearGradient id="missingGradientDecreasing">
+  <stop offset="0%" stop-opacity="1" />
+  <stop offset="50%" stop-opacity="0.75" />
+  <stop offset="100%" stop-opacity="0" />
+</linearGradient>
+
+<linearGradient id="missingGradientIncreasing">
+  <stop offset="0%" stop-opacity="0" />
+  <stop offset="50%" stop-opacity="0.75" />
+  <stop offset="100%" stop-opacity="1" />
+</linearGradient>
+
+<linearGradient id="missingGradientNull">
+  <stop offset="0%" stop-opacity="0" />
+  <stop offset="50%" stop-opacity="0" />
+  <stop offset="100%" stop-opacity="0" />
+</linearGradient>


### PR DESCRIPTION
The gradient variant has three options, decreasing opacity, increasing opacity, or 0 opacity,
depending on which axis is missing a value. This has been implemented now. We need to make sure to
account for colors once we have implemented color-coded lines.

fix #166