### PR TITLE
style: improve storybook appearance slightly

### DIFF
--- a/packages/storybook/.storybook/manager.js
+++ b/packages/storybook/.storybook/manager.js
@@ -1,0 +1,24 @@
+import { addons } from '@storybook/addons';
+
+addons.setConfig({
+  isFullscreen: false,
+  showNav: true,
+  showPanel: true,
+  panelPosition: 'right',
+  enableShortcuts: true,
+  showToolbar: true,
+  theme: undefined,
+  selectedPanel: undefined,
+  initialActive: 'sidebar',
+  sidebar: {
+    showRoots: false,
+    collapsedRoots: ['other'],
+  },
+  toolbar: {
+    title: { hidden: false },
+    zoom: { hidden: false },
+    eject: { hidden: false },
+    copy: { hidden: false },
+    fullscreen: { hidden: false },
+  },
+});

--- a/packages/storybook/stories/PCDemo.svelte
+++ b/packages/storybook/stories/PCDemo.svelte
@@ -44,7 +44,7 @@
         window.open("https://github.com/Sparkier/Missing-Coordinates")}
     >
       <img src={githubImage} alt="github mark" />
-      <div>View on GitHub</div>
+      <div class="nowrap">View on GitHub</div>
     </button>
   </div>
   <div class="main-div">
@@ -103,7 +103,8 @@
     background-color: #eee;
   }
   img {
-    height: 100%;
+    height: 14px;
+    width: 14px;
     padding-right: 0.5em;
   }
   button {
@@ -141,5 +142,8 @@
   }
   .header {
     font-size: 2em;
+  }
+  .nowrap {
+    white-space: nowrap;
   }
 </style>


### PR DESCRIPTION
The text in the github button does not wrap anymore and the controls are on the right per default
now.